### PR TITLE
Add histogram/4 to hyperfunctions

### DIFF
--- a/lib/timescale/hyperfunctions.ex
+++ b/lib/timescale/hyperfunctions.ex
@@ -20,6 +20,30 @@ defmodule Timescale.Hyperfunctions do
   end
 
   @doc """
+  The histogram function represents the distribution of a set of values as an array of equal-width buckets. 
+  It partitions the dataset into a specified number of buckets (nbuckets) ranging from the inputted min and max values.
+
+  The return value is an array containing nbuckets+2 buckets, with the middle nbuckets bins for values in the 
+  stated range, the first bucket at the head of the array for values under the lower min bound, and the last bucket 
+  for values greater than or equal to the max bound. Each bucket is inclusive on its lower bound, 
+  and exclusive on its upper bound. Therefore, values equal to the min are included in the bucket starting with min, 
+  but values equal to the max are in the last bucket.
+
+  [Documentation](https://docs.timescale.com/api/latest/hyperfunctions/histogram/)
+  """
+  defmacro histogram(field, min, max, buckets) do
+    quote do
+      fragment(
+        "histogram(?, ?, ?, ?)",
+        unquote(field),
+        unquote(min),
+        unquote(max),
+        unquote(buckets)
+      )
+    end
+  end
+
+  @doc """
   The last aggregate allows you to get the value of one column as ordered by another.
   For example, `last(temperature, time)` returns the latest temperature value based on time within an aggregate group.
 

--- a/test/timescale/hyperfunction_test.exs
+++ b/test/timescale/hyperfunction_test.exs
@@ -13,6 +13,13 @@ defmodule Timescale.HyperfunctionTest do
     )
   end
 
+  test "histogram/4 generates a valid query" do
+    assert_sql(
+      from(r in Table, select: histogram(r.a, 20, 60, 5)),
+      ~s[SELECT histogram(m0."a", 20, 60, 5) FROM "my_table" AS m0]
+    )
+  end
+
   test "last/2 generates a valid query" do
     assert_sql(
       from(r in Table, select: last(r.a, r.timestamp)),


### PR DESCRIPTION
Continuing to chip away at #1. This PR adds `histogram` support.