### PR TITLE
feat: setup a release action for publishing to hex.pm

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
-# create this in .github/workflows/ci.yml
 name: CI
+
 on:
   pull_request:
   push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  Hex:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install (Elixir)
+        id: beam
+        uses: erlef/setup-beam@v1
+        with:
+          otp-version: 25
+          elixir-version: 1.13
+
+      - name: Cache
+        uses: actions/cache@v3
+        id: cache
+        with:
+          key: elixir-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-${{ hashFiles('mix.lock') }}-${{ github.ref }}
+          restore-keys: |
+            elixir-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-${{ hashFiles('mix.lock') }}-refs/heads/${{ github.event.repository.default_branch }}
+            elixir-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-release-
+            elixir-${{ steps.beam.outputs.elixir-version }}-${{ steps.beam.outputs.otp-version }}-
+          path: |
+            _build
+            deps
+
+      - name: Install (Mix)
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile --docs
+
+      - name: Release
+        run: mix hex.publish --yes
+        with:
+          HEX_API_KEY: ${{ secrets.HEXPM_SECRET }}

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,7 @@ defmodule Timescale.MixProject do
   def package do
     [
       licenses: ["Apache-2.0"],
+      files: ["lib", "mix.exs", "README.md", "LICENSE"],
       links: %{
         "GitHub" => @repo_url
       }


### PR DESCRIPTION
Fixes #18 by adding a GitHub action that publishes to hex.pm on new git releases.

Most of the logic was stolen from https://github.com/beam-community/avro_ex/blob/master/.github/workflows/deploy.yml

Requires a `HEXPM_SECRET` secret to be added to the repo.