### PR TITLE
Update README migration docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ defmodule MyApp.Repo.Migrations.SetupTimescale do
   import Timescale.Migration
 
   def up do
-    add_timescaledb_extension()
+    create_timescaledb_extension()
   end
 
   def down do


### PR DESCRIPTION
Looks like the `add_timescaledb_extension()` function was changed to
`create_timescaledb_extension()`. I updated the README to reflect that
change.