### PR TITLE
Use the timescaledb-ha image with the toolkit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
 
     services:
       db:
-        image: timescale/timescaledb:latest-pg14
+        image: timescale/timescaledb-ha:pg14-latest
         ports: ["5432:5432"]
         env:
           POSTGRES_PASSWORD: postgres


### PR DESCRIPTION
The `timescale/timescaledb-ha:pg14-latest` ships with the timescale toolkit, which will be needed for the gapfill functions