### PR TITLE
deprecate time_bucket_ng

### DIFF
--- a/lib/timescale/hyperfunctions.ex
+++ b/lib/timescale/hyperfunctions.ex
@@ -99,26 +99,4 @@ defmodule Timescale.Hyperfunctions do
       :origin
     ])
   end
-
-  @doc """
-  This experimental TimescaleDB function works identically to `time_bucket/2` with the added benefit that
-  you can aggregate by month, year or timezone.
-  For example, `time_bucket_ng(timestamp, "5 years")` would allow you to group results into 5 year buckets.
-
-  - `:origin` - The timestamp used to align all of the time buckets. (Postgres type: "DATE", "TIMESTAMP", or "TIMESTAMPZ")
-  - `:timezone` - The name of the timezone. (Postgres type: "TEXT")
-
-  [Documentation](https://docs.timescale.com/api/latest/hyperfunctions/time_bucket_ng/)
-  """
-  defmacro time_bucket_ng(field, time_bucket, optional_args \\ []) do
-    dynamic_function_fragment(
-      :"timescaledb_experimental.time_bucket_ng",
-      [time_bucket, field],
-      optional_args,
-      [
-        :origin,
-        :timezone
-      ]
-    )
-  end
 end

--- a/test/timescale/hyperfunction_test.exs
+++ b/test/timescale/hyperfunction_test.exs
@@ -64,44 +64,4 @@ defmodule Timescale.HyperfunctionTest do
       ~s[SELECT time_bucket('5 minutes', t0."timestamp", offset => '2.5 minutes', origin => '1900-01-01') FROM "test_hypertable" AS t0]
     )
   end
-
-  test "time_bucket_ng/2 generates a valid query" do
-    assert_sql(
-      from(t in Table, select: time_bucket_ng(t.timestamp, "5 years")),
-      ~s[SELECT timescaledb_experimental.time_bucket_ng('5 years', t0."timestamp") FROM "test_hypertable" AS t0]
-    )
-  end
-
-  test "time_bucket_ng/2 should raise an error if an invalid option is provided" do
-    assert_raise Timescale.OptionalArgError,
-                 "The timescaledb_experimental.time_bucket_ng TimescaleDB function does support the following options: [:invalid_opt]",
-                 fn ->
-                   Code.eval_string("""
-                   import Ecto.Query
-                   import Timescale.Hyperfunctions
-
-                   from(t in Table,
-                     select: time_bucket_ng(t.timestamp, "5 years", invalid_opt: "bad data")
-                   )
-                   """)
-                 end
-  end
-
-  test "time_bucket_ng/3 generates a valid query with optional params" do
-    assert_sql(
-      from(t in Table,
-        select:
-          time_bucket_ng(t.timestamp, "5 minutes", origin: "1900-01-01", timezone: "Europe/Athens")
-      ),
-      ~s[SELECT timescaledb_experimental.time_bucket_ng('5 minutes', t0."timestamp", origin => '1900-01-01', timezone => 'Europe/Athens') FROM "test_hypertable" AS t0]
-    )
-
-    assert_sql(
-      from(t in Table,
-        select:
-          time_bucket_ng(t.timestamp, "5 minutes", timezone: "Europe/Athens", origin: "1900-01-01")
-      ),
-      ~s[SELECT timescaledb_experimental.time_bucket_ng('5 minutes', t0."timestamp", timezone => 'Europe/Athens', origin => '1900-01-01') FROM "test_hypertable" AS t0]
-    )
-  end
 end

--- a/test/timescale/integration_test.exs
+++ b/test/timescale/integration_test.exs
@@ -81,9 +81,7 @@ defmodule Timescale.IntegrationTest do
                {5.0, ~N[1989-09-22 12:05:00.000000]}
              ]
     end
-  end
 
-  describe "time_bucket_ng/3" do
     test "can bucket by months" do
       timezone_fixture(0.0, ~U[2020-01-22 12:00:00.000000Z])
       timezone_fixture(1.0, ~U[2020-02-22 12:01:00.000000Z])
@@ -92,9 +90,7 @@ defmodule Timescale.IntegrationTest do
       timezone_fixture(4.0, ~U[2020-05-22 12:04:00.000000Z])
       timezone_fixture(5.0, ~U[2020-06-22 12:05:00.000000Z])
 
-      assert Repo.all(
-               from(t in TZTable, select: {t.field, time_bucket_ng(t.timestamp, "2 month")})
-             ) ==
+      assert Repo.all(from(t in TZTable, select: {t.field, time_bucket(t.timestamp, "2 month")})) ==
                [
                  {0.0, ~N[2020-01-01 00:00:00.000000]},
                  {1.0, ~N[2020-01-01 00:00:00.000000]},
@@ -102,33 +98,6 @@ defmodule Timescale.IntegrationTest do
                  {3.0, ~N[2020-03-01 00:00:00.000000]},
                  {4.0, ~N[2020-05-01 00:00:00.000000]},
                  {5.0, ~N[2020-05-01 00:00:00.000000]}
-               ]
-    end
-
-    test "can set an origin with a named option" do
-      timezone_fixture(0.0, ~U[2020-01-22 12:00:00.000000Z])
-      timezone_fixture(1.0, ~U[2020-02-22 12:01:00.000000Z])
-      timezone_fixture(2.0, ~U[2020-03-22 12:02:00.000000Z])
-      timezone_fixture(3.0, ~U[2020-04-22 12:03:00.000000Z])
-      timezone_fixture(4.0, ~U[2020-05-22 12:04:00.000000Z])
-      timezone_fixture(5.0, ~U[2020-06-22 12:05:00.000000Z])
-
-      assert Repo.all(
-               from(t in TZTable,
-                 select:
-                   {t.field,
-                    time_bucket_ng(t.timestamp, "2 month",
-                      origin: ^~U[2019-12-01 00:00:00.000000Z]
-                    )}
-               )
-             ) ==
-               [
-                 {0.0, ~N[2019-12-01 00:00:00.000000]},
-                 {1.0, ~N[2020-02-01 00:00:00.000000]},
-                 {2.0, ~N[2020-02-01 00:00:00.000000]},
-                 {3.0, ~N[2020-04-01 00:00:00.000000]},
-                 {4.0, ~N[2020-04-01 00:00:00.000000]},
-                 {5.0, ~N[2020-06-01 00:00:00.000000]}
                ]
     end
   end


### PR DESCRIPTION
Its main functionality, such as monthly bucketing and timezone support are now part of `time_bucket`