### PR TITLE
Add reversible migrations and more options

### DIFF
--- a/lib/timescale/migration.ex
+++ b/lib/timescale/migration.ex
@@ -7,46 +7,185 @@ defmodule Timescale.Migration do
 
   @doc """
   Adds TimescaleDB as a Postgres extension
+
+  Options:
+  - `:schema` `string` The name of the schema in which to install the extensions' objects.
+  - `:version` `string` The version of the extension to install.
+  - `:cascade` `true|false` In the up direction, automatically install any extensions that this extension depends on that are not already installed. In the down direction, forcibly remove any dependent objects.
+  - `:if_exists` `true|false` In the down direction, drop extension only if it exists. Default: `true`
+  - `:if_not_exists` `true|false` In the up direction, create extension only if it doesn't exists. Default: `true`
   """
-  defmacro create_timescaledb_extension do
-    quote do
-      Ecto.Migration.execute("CREATE EXTENSION IF NOT EXISTS timescaledb CASCADE")
+  defmacro create_timescaledb_extension(opts \\ []) do
+    schema = if opts[:schema], do: "SCHEMA #{opts[:schema]}"
+    version = if opts[:version], do: "VERSION '#{opts[:version]}'"
+    cascade = if opts[:cascade], do: "CASCADE"
+    if_exists = if Keyword.get(opts, :if_exists, true), do: "IF EXISTS"
+    if_not_exists = if Keyword.get(opts, :if_not_exists, true), do: "IF NOT EXISTS"
+
+    quote bind_quoted: [
+            schema: schema,
+            version: version,
+            cascade: cascade,
+            if_exists: if_exists,
+            if_not_exists: if_not_exists
+          ] do
+      Ecto.Migration.execute(
+        trim("CREATE EXTENSION #{if_not_exists} timescaledb #{schema} #{version} #{cascade}"),
+        trim("DROP EXTENSION #{if_exists} timescaledb #{cascade}")
+      )
     end
   end
 
   @doc """
   Drops TimescaleDB as a Postgres extension
+
+  Options:
+  - `:cascade` `true|false` In the up direction, automatically install any extensions that this extension depends on that are not already installed. In the down direction, forcibly remove any dependent objects.
+  - `:if_exists` `true|false` Drop extension only if it exists. Default: `true`
+
+  Down direction options:
+  - `:if_not_exist` `true|false` In the down direction, create extension only if it doesn't exists. Default: `true`
+  - `:cascade` `true|false` See earlier `:cascade` option.
+  - `:schema` `string` The name of the schema in which to install the extensions' objects.
+  - `:version` `string` The version of the extension to install.
   """
-  defmacro drop_timescaledb_extension do
-    quote do
-      Ecto.Migration.execute("DROP EXTENSION IF EXISTS timescaledb CASCADE")
+  defmacro drop_timescaledb_extension(opts \\ []) do
+    if_exists = if Keyword.get(opts, :if_exists, true), do: "IF EXISTS"
+    if_not_exists = if Keyword.get(opts, :if_not_exists, true), do: "IF NOT EXISTS"
+    cascade = if opts[:cascade], do: "CASCADE"
+    schema = if opts[:schema], do: "SCHEMA #{opts[:schema]}"
+    version = if opts[:version], do: "VERSION '#{opts[:version]}'"
+
+    quote bind_quoted: [
+            schema: schema,
+            version: version,
+            cascade: cascade,
+            if_exists: if_exists,
+            if_not_exists: if_not_exists
+          ] do
+      Ecto.Migration.execute(
+        trim("DROP EXTENSION #{if_exists} timescaledb #{cascade}"),
+        trim("CREATE EXTENSION #{if_not_exists} timescaledb #{schema} #{version} #{cascade}")
+      )
     end
   end
 
   @doc """
   Adds the [TimescaleDB toolkit](https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/#install-and-update-timescaledb-toolkit) as a Postgres Extension
+
+  Options:
+  - `:schema` `string` The name of the schema in which to install the extensions' objects.
+  - `:version` `string` The version of the extension to install.
+  - `:cascade` `true|false` In the up direction, automatically install any extensions that this extension depends on that are not already installed. In the down direction, forcibly remove any dependent objects.
+  - `:if_not_exist` `true|false` Create extension only if it doesn't exists. Default: `true`
+
+  Down direction options:
+  - `:if_exists` `true|false` In the up direction, drop extension only if it exists. Default: `true`
+  - `:cascade` `true|false` See earlier `:cascade` option.
   """
-  defmacro create_timescaledb_toolkit_extension do
-    quote do
-      Ecto.Migration.execute("CREATE EXTENSION IF NOT EXISTS timescaledb_toolkit CASCADE")
+  defmacro create_timescaledb_toolkit_extension(opts \\ []) do
+    schema = if opts[:schema], do: "SCHEMA #{opts[:schema]}"
+    version = if opts[:version], do: "VERSION '#{opts[:version]}'"
+    cascade = if opts[:cascade], do: "CASCADE"
+    if_exists = if Keyword.get(opts, :if_exists, true), do: "IF EXISTS"
+    if_not_exists = if Keyword.get(opts, :if_not_exists, true), do: "IF NOT EXISTS"
+
+    quote bind_quoted: [
+            schema: schema,
+            version: version,
+            cascade: cascade,
+            if_exists: if_exists,
+            if_not_exists: if_not_exists
+          ] do
+      Ecto.Migration.execute(
+        trim(
+          "CREATE EXTENSION #{if_not_exists} timescaledb_toolkit #{schema} #{version} #{cascade}"
+        ),
+        trim("DROP EXTENSION #{if_exists} timescaledb_toolkit #{cascade}")
+      )
+    end
+  end
+
+  @doc """
+  Updates the existing [TimescaleDB](https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/#install-and-update-timescaledb-toolkit) extension
+
+  Irreversible migration.
+
+  Options:
+  - `:set_schema` `string` The name of the schema in which to update the extensions' objects.
+    If this is set, the `to_version` option will be ignored.
+    If you need to set the schema and upate to a version, call this function twice with each option.
+  - `:to_version` `string` In the up direction, the version of the extension to update to.
+  """
+  defmacro update_timescaledb_extension(opts \\ []) do
+    if schema = opts[:schema] do
+      quote bind_quoted: [schema: schema] do
+        Ecto.Migration.execute("ALTER EXTENSION timescaledb SET SCHEMA #{schema}")
+      end
+    else
+      to_version = if opts[:to_version], do: "TO '#{opts[:to_version]}'"
+
+      quote bind_quoted: [to_version: to_version] do
+        Ecto.Migration.execute(trim("ALTER EXTENSION timescaledb UPDATE #{to_version}"), "")
+      end
     end
   end
 
   @doc """
   Updates the existing [TimescaleDB toolkit](https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/#install-and-update-timescaledb-toolkit) extension
+
+  Irreversible migration.
+
+  Options:
+  - `:to_version` `string` In the up direction, the version of the extension to update to.
   """
-  defmacro update_timescaledb_toolkit_extension do
-    quote do
-      Ecto.Migration.execute("ALTER EXTENSION timescaledb_toolkit UPDATE")
+  defmacro update_timescaledb_toolkit_extension(opts \\ []) do
+    if opts[:schema],
+      do:
+        raise(Timescale.MigrationArgError,
+          function: :update_timescaledb_toolkit_extension,
+          invalid_args: [:schema]
+        )
+
+    to_version = if opts[:to_version], do: "TO '#{opts[:to_version]}'"
+
+    quote bind_quoted: [to_version: to_version] do
+      Ecto.Migration.execute(trim("ALTER EXTENSION timescaledb_toolkit UPDATE #{to_version}"))
     end
   end
 
   @doc """
   Drops the [TimescaleDB toolkit](https://docs.timescale.com/timescaledb/latest/how-to-guides/hyperfunctions/install-toolkit/#install-and-update-timescaledb-toolkit) as a Postgres Extension
+
+  Options:
+  - `:cascade` `true|false` Forcibly remove dependant objects.
+  - `:if_exists` `true|false` Drop extension only if it exists. Default: `true`
+
+  Down direction options:
+  - `:if_not_exist` `true|false` Create extension only if it doesn't exists. Default: `true`
+  - `:schema` `string` The name of the schema in which to install the extensions' objects.
+  - `:version` `string` The version of the extension to install.
   """
-  defmacro drop_timescaledb_toolkit_extension do
-    quote do
-      Ecto.Migration.execute("DROP EXTENSION IF EXISTS timescaledb_toolkit CASCADE")
+  defmacro drop_timescaledb_toolkit_extension(opts \\ []) do
+    if_exists = if Keyword.get(opts, :if_exists, true), do: "IF EXISTS"
+    if_not_exists = if Keyword.get(opts, :if_not_exists, true), do: "IF NOT EXISTS"
+    cascade = if opts[:cascade], do: "CASCADE"
+    schema = if opts[:schema], do: "SCHEMA #{opts[:schema]}"
+    version = if opts[:version], do: "VERSION '#{opts[:version]}'"
+
+    quote bind_quoted: [
+            schema: schema,
+            version: version,
+            cascade: cascade,
+            if_exists: if_exists,
+            if_not_exists: if_not_exists
+          ] do
+      Ecto.Migration.execute(
+        trim("DROP EXTENSION #{if_exists} timescaledb_toolkit #{cascade}"),
+        trim(
+          "CREATE EXTENSION #{if_not_exists} timescaledb_toolkit #{schema} #{version} #{cascade}"
+        )
+      )
     end
   end
 

--- a/lib/timescale/migration_utils.ex
+++ b/lib/timescale/migration_utils.ex
@@ -88,4 +88,6 @@ defmodule Timescale.MigrationUtils do
       raise MigrationArgError, function: function_name, invalid_args: remaining_invalid_keys
     end
   end
+
+  def trim(string) when is_binary(string), do: string |> String.split() |> Enum.join(" ")
 end

--- a/test/timescale/migration_test.exs
+++ b/test/timescale/migration_test.exs
@@ -2,29 +2,46 @@ defmodule Timescale.MigrationTest do
   use ExUnit.Case
   use Ecto.Migration
 
-  test "add_compression_policy/3 should raise an error if an invalid option is provided" do
-    assert_raise Timescale.MigrationArgError,
-                 "The add_compression_policy TimescaleDB function does support the following options: [:invalid_opt]",
-                 fn ->
-                   Code.eval_string("""
-                   import Ecto.Query
-                   import Timescale.Migration
+  describe "migration options" do
+    test "update_timescaledb_toolkit_extension does not support schema" do
+      assert_raise Timescale.MigrationArgError,
+                   "The update_timescaledb_toolkit_extension TimescaleDB function does support the following options: [:schema]",
+                   fn ->
+                     Code.eval_string("""
+                     import Ecto.Query
+                     import Timescale.Migration
 
-                   add_compression_policy(:my_ts_table, "5 hours", invalid_opt: "bad_data")
-                   """)
-                 end
+                     update_timescaledb_toolkit_extension(schema: "FOO")
+                     """)
+                   end
+    end
   end
 
-  test "remove_compression_policy/3 should raise an error if an invalid option is provided" do
-    assert_raise Timescale.MigrationArgError,
-                 "The remove_compression_policy TimescaleDB function does support the following options: [:if_not_exists]",
-                 fn ->
-                   Code.eval_string("""
-                   import Ecto.Query
-                   import Timescale.Migration
+  describe "compression" do
+    test "add_compression_policy/3 should raise an error if an invalid option is provided" do
+      assert_raise Timescale.MigrationArgError,
+                   "The add_compression_policy TimescaleDB function does support the following options: [:invalid_opt]",
+                   fn ->
+                     Code.eval_string("""
+                     import Ecto.Query
+                     import Timescale.Migration
 
-                   remove_compression_policy(:my_ts_table, if_not_exists: true)
-                   """)
-                 end
+                     add_compression_policy(:my_ts_table, "5 hours", invalid_opt: "bad_data")
+                     """)
+                   end
+    end
+
+    test "remove_compression_policy/3 should raise an error if an invalid option is provided" do
+      assert_raise Timescale.MigrationArgError,
+                   "The remove_compression_policy TimescaleDB function does support the following options: [:if_not_exists]",
+                   fn ->
+                     Code.eval_string("""
+                     import Ecto.Query
+                     import Timescale.Migration
+
+                     remove_compression_policy(:my_ts_table, if_not_exists: true)
+                     """)
+                   end
+    end
   end
 end


### PR DESCRIPTION
- Allow `schema` as an configurable option when creating extensions
- Allow `cascade` to be a configurable option when creating/dropping extensions.
- Allow `if exists` and `if not exists` to be configurable options.
- Creating and dropping extensions are now reversible.