### PR TITLE
Fix CI for OTP 23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   Credo:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -42,7 +42,7 @@ jobs:
         run: mix credo
 
   Dialyzer:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -76,7 +76,7 @@ jobs:
         run: mix dialyzer
 
   Format:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - name: Checkout
@@ -96,7 +96,7 @@ jobs:
 
   Test:
     name: Test (Elixir ${{ matrix.versions.elixir }} OTP ${{ matrix.versions.otp }})
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     services:
       db:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: 25
-          elixir-version: 1.13
+          elixir-version: 1.14
 
       - name: Cache
         uses: actions/cache@v3
@@ -53,7 +53,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: 25
-          elixir-version: 1.13
+          elixir-version: 1.14
 
       - name: Cache
         uses: actions/cache@v3
@@ -86,7 +86,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: 25
-          elixir-version: 1.13
+          elixir-version: 1.14
 
       - name: Install (Mix)
         run: mix deps.get
@@ -120,7 +120,7 @@ jobs:
             otp: 24
           - elixir: 1.13
             otp: 25
-          - elixir: "1.14.0-rc.1"
+          - elixir: 1.14
             otp: 25
 
     env:


### PR DESCRIPTION
Support at this point for the setup-beam action:


Operating system | Erlang/OTP | Status
-- | -- | --
ubuntu-18.04 | 17 - 25 | ✅
ubuntu-20.04 | 20 - 25 | ✅
ubuntu-22.04 | 24.2 - 25 | ✅
windows-2019 | 21* - 25 | ✅
windows-2022 | 21* - 25 | ✅




Since we're testing backwards to OTP-23, looks like we need to stay on ubuntu-20.04 OR drop OTP 23 from the CI pipeline.